### PR TITLE
Support a single language installation

### DIFF
--- a/24Days.Web/App_Plugins/BlockListViews/Blocks/block-preview.controller.js
+++ b/24Days.Web/App_Plugins/BlockListViews/Blocks/block-preview.controller.js
@@ -3,7 +3,7 @@ angular.module('umbraco').controller('TwentyFourDays.Controllers.BlockPreviewCon
     function ($scope,$sce, $timeout, editorState, previewResource) {
       $scope.language = editorState.getCurrent().variants.find(function (v) {
         return v.active;
-      }).language.culture;
+      }).language?.culture;
 
       $scope.id = editorState.getCurrent().id;
         $scope.loading = true;


### PR DESCRIPTION
In simple single language site setups 'language' was undefined and throwing a JS error in the console.